### PR TITLE
added prune node options

### DIFF
--- a/btc.yml
+++ b/btc.yml
@@ -21,7 +21,7 @@ services:
     environment:
         - DISABLEWALLET=1
         - PRINTTOCONSOLE=1
-        - TXINDEX=1
+        - TXINDEX=${TXINDEX:-1}
         - RPCUSER=${RPC_USER}
         - RPCPASSWORD=${RPC_PW}
     stop_grace_period: 1m
@@ -36,7 +36,6 @@ services:
     <<: *logging
     entrypoint:
       - docker-entrypoint.sh
-    command:
       - btc_oneshot
       - -rpcbind=:8332
       - -rpcallowip=0.0.0.0/0

--- a/default.env
+++ b/default.env
@@ -7,6 +7,10 @@ GPG_SIGNATURE=152812300785C96444D3334D17565732E08E5E41
 RPC_USER=
 RPC_PW=
 
+# Set to 0 to use pruned mode
+TXINDEX=1
+EXTRA_BITCOIND_FLAG=
+
 # Secure web proxy - advanced use, please see https://ethdocker.com/Usage/ReverseProxy
 DOMAIN=example.com
 ACME_EMAIL=user@example.com

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,10 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 	set -- btc_oneshot "$@"
 fi
 
+if [ -n "${EXTRA_BITCOIND_FLAG}" ]; then
+    set -- "$@" ${EXTRA_BITCOIND_FLAG}
+fi
+
 # Allow the container to be started with `--user`, if running as root drop privileges
 if [ "$1" = 'btc_oneshot' -a "$(id -u)" = '0' ]; then
 	chown -R bitcoin .


### PR DESCRIPTION
This pull request introduces configuration improvements and increased flexibility for the Bitcoin service setup. The changes focus on enhancing environment variable usage, adding support for custom flags, and improving command handling in the Docker entrypoint script.

### Configuration Improvements:

* [`btc.yml`](diffhunk://#diff-5e2ce091d0eaa48301efd9bbe0c24911d11a98eabdb047ab663cca60391f7f59L24-R24): Updated the `TXINDEX` environment variable to allow dynamic configuration using `${TXINDEX:-1}`, enabling default values while supporting overrides.
* [`default.env`](diffhunk://#diff-809f8c700609ab7a6e6a2efafcd1c6a92b66ab54df793dafe3bec16c5387107aR10-R13): Added new variables `TXINDEX` and `EXTRA_BITCOIND_FLAG` for configuring pruned mode and additional Bitcoin daemon flags, respectively.

### Increased Flexibility in Command Handling:

* [`docker-entrypoint.sh`](diffhunk://#diff-79738685a656fe6b25061bb14181442210b599f746faeaba408a2401de45038aR10-R13): Added logic to append the `EXTRA_BITCOIND_FLAG` variable to the command if it is set, allowing custom Bitcoin daemon flags to be passed dynamically.

### Removed Redundant Command:

* [`btc.yml`](diffhunk://#diff-5e2ce091d0eaa48301efd9bbe0c24911d11a98eabdb047ab663cca60391f7f59L39): Removed the `command` section under `services`, simplifying the configuration and relying on the entrypoint script for command setup.